### PR TITLE
Remove duplicate 'are' typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Having a running version of FarmData2 is a prerequisite for many of the forms of
 
 #### Bug Reports ####
 
-If you are are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
+If you are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss what you have found and how to proceed.
   * Search the [Issue Tracker] to see if the bug has been reported already.
@@ -37,7 +37,7 @@ If you are are a user of FarmData2 and discover something that doesn't seem to b
 
 #### Feature Requests ####
 
-If you are are a user of FarmData2 and have a new feature you would like to see you can:
+If you are a user of FarmData2 and have a new feature you would like to see you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss the feature you'd like to see and how to proceed.
   * Search the [Issue Tracker] to see if the feature, or something close, has already been suggested by someone.


### PR DESCRIPTION
__Pull Request Description__

Removed duplicate "are' typos located in the CONTRIBUTING.md file. Fixes issue #18  

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
