### PR TITLE
Remove extra word in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,4 +31,4 @@ All other content, including code snippets posted in public forums, is licensed 
 
 Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system.  The [AUTHORS.md](AUTHORS.md) file contains a list of all contributors to the repository and is updated periodically.
 
-Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made based.
+Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made.


### PR DESCRIPTION
Resolves #27 

Removes the extra word "based" in LICENSE.md.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
